### PR TITLE
Fixes #1 Integrates github issue tracker regexes in commit-msg hooks

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -4,12 +4,14 @@
 current_repo="$(basename `git rev-parse --show-toplevel`)"
 
 # only check commit messages on mosip repo
-[ "$current_repo" != "mosip" ] && exit 0
+[[ "$current_repo" != "mosip"* ]] && exit 0
 
 # regex to validate in commit msg
-commit_regex='(^MOS-[0-9]+|^Merge|^merge)'
+commit_regex='(^MOS-[0-9]+|^Merge|^Close|^Closes|^Closed|^Fix|^Fixes|^Fixed|^Resolve|^Resolves|^Resolved|^GH-[0-9]+)'
 error_msg="Aborting commit. Your commit message should start with JIRA Issue like  MOS-1111 or 'merge'"
+github_error_msg="Your commit can also start with Close(s|d)/Fix(es|ed)/Resolve(d|s) followed by a github issue number"
 if ! grep -iqE "$commit_regex" "$1"; then
     echo "$error_msg" >&2
+    echo "$github_error_msg" >&2
     exit 1
 fi


### PR DESCRIPTION
- grep `-i` includes case insensitivity, therefore removing `^merge` since `^Merge` exists.
- Adds github corresponding words for future issue tracking.
- Tests the `commit-msg` on this commit by adding the `commit-msg` hook to the hooks of this repository
- Change the hooks to play a role on all `mosip-*` projects than only a project called `mosip`.