### PR TITLE
[MOSIP-1806] Limit range set for namespace default removed as we are

### DIFF
--- a/deployment/sandbox-v2/helm/charts/ingress-nginx/templates/ingress-init.yaml
+++ b/deployment/sandbox-v2/helm/charts/ingress-nginx/templates/ingress-init.yaml
@@ -269,23 +269,6 @@ spec:
                   - /wait-shutdown
 
 ---
-
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: ingress-nginx
-  namespace: {{ .Values.namespace }} 
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
-spec:
-  limits:
-  - min:
-      memory: 90Mi
-      cpu: 100m
-    type: Container
-
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
not setting any limits as of now.