### PR TITLE
Postgres init and IDA start sequence issues fixed

### DIFF
--- a/deployment/sandbox-v2/README.md
+++ b/deployment/sandbox-v2/README.md
@@ -139,6 +139,10 @@ $ an reset.yml
 ## Persistence
 All persistent data is available over Network File System (NFS) hosted on the console at location `/srv/nfs/mosip`.  All pods write into this location for any persistent data.  You may backup this folder if needed.
 
+Note the following:
+* Postgres is initialized and populated only once.  If persistent data is present in `/srv/nfs/mosip/postgres` then postgres is not initialized. You will need to run reset scripts to clear up the folder for a re-initialization.
+* Postgres also contains Keycloak data.  `keycloak-init` does not overwrite any data, but just updates and adds.  If you want to clean up Keycloak data, you will need to clean it up manually or reset entire postgres.
+
 ## Useful tools
 * If you use `tmux` tool, copy the config file as below:
 ```

--- a/deployment/sandbox-v2/helm/charts/ida/README.md
+++ b/deployment/sandbox-v2/helm/charts/ida/README.md
@@ -1,3 +1,22 @@
+## Softhsm
 IDA connects to softhsm.  Each IDA service connects to corresponding softhsm (1-1).  So before running each IDA service we have to run softhsm instance.  See role/softhsm  and playbooks/softhsm.yml for more details.
 
 Note that we have not combined the softhsm installation has part of this Helm package, as softhsm in not part of IDA.  In production, there won't be any softhsm, but an actual hardware HSM.  
+
+## Interdependencies
+Following is the sequence of IDA pod exectution:
+
+1.  Generator jobs
+1.  id-auth-service
+1.  Other services
+
+Generator jobs are run before using annotation  
+    ```
+    "helm.sh/hook": pre-install`
+    "helm.sh/hook-delete-policy": hook-succeeded
+    ```
+
+The second annotation ensures these jobs get deleted on `helm delete`
+
+Dependency between services is ensure using kubernetes `initContainers`.
+

--- a/deployment/sandbox-v2/helm/charts/ida/templates/encryptsalt-job.yaml
+++ b/deployment/sandbox-v2/helm/charts/ida/templates/encryptsalt-job.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ .Values.generators.encryptsalt.name }}
     component: {{ .Values.component }} 
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
     
 spec:
   template:

--- a/deployment/sandbox-v2/helm/charts/ida/templates/hashsalt-job.yaml
+++ b/deployment/sandbox-v2/helm/charts/ida/templates/hashsalt-job.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ .Values.generators.hashsalt.name }}
     component: {{ .Values.component }} 
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
     
 spec:
   template:

--- a/deployment/sandbox-v2/helm/charts/ida/templates/keys-job.yaml
+++ b/deployment/sandbox-v2/helm/charts/ida/templates/keys-job.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ .Values.generators.key.name }}
     component: {{ .Values.component }} 
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
     
 spec:
   template:

--- a/deployment/sandbox-v2/playbooks/postgres.yml
+++ b/deployment/sandbox-v2/playbooks/postgres.yml
@@ -31,10 +31,20 @@
       pause:
         seconds: 30 
 
+# Initialize postgres with data.
 # Separate play for init to keep sequence of execution
+# First check if postgres is already init. If so, don't init it
 - hosts: console
-  roles:
-     - {role: repos, tags: [repos]}  # These repos have sql scripts
-     - {role: postgres-init, tags: [postgres-init]} 
+  gather_facts: false
+  tasks:
+    - name: Check if db already exists. Don't init if it does 
+      import_tasks: '../roles/common/tasks/db_exists.yml'
+      vars:
+        db_name: mosip_kernel  # Just any db. If exists, we will not init
+
+- hosts: console
+  roles:  # Run these roles only if db does not exist
+     - {role: repos, when: db_exists == false, tags: [repos]}  # These repos have sql scripts. 
+     - {role: postgres-init, when: db_exists == false,  tags: [postgres-init]} 
 
 

--- a/deployment/sandbox-v2/roles/common/tasks/db_exists.yml
+++ b/deployment/sandbox-v2/roles/common/tasks/db_exists.yml
@@ -1,0 +1,24 @@
+# Tasks to check if a postgres db exists.  Sets 'db_exists' variable as true/false.
+# The task needs db_name as input.  Rest are picked from global settings.
+# params: db_name
+# returns: db_exists
+
+- name: Select query to db acme with positional arguments and non-default credentials
+  postgresql_query:
+    db: '{{db_name}}'
+    login_host: '{{postgres.server}}'
+    port: '{{postgres.nodeport}}'
+    login_user: '{{postgres.user}}'
+    login_password: '{{postgres.password}}' 
+    query:  SELECT version()
+  register: result
+  failed_when: ' "" in result'
+
+- set_fact:
+    db_exists: false
+
+- set_fact:
+    db_exists: true
+  when: '"query_result" in result'
+
+


### PR DESCRIPTION
* Postgres init happens only once.  If db exists, init skips.  To init, you need to now reset the postgres persistence folders.
* There was a sequence problem in IDA jobs.  The jobs need to run before the services start.  This has been done.