### PR TITLE
Update kubeadm version from 1.18.0 to 1.19.0

### DIFF
--- a/deployment/sandbox-v2/group_vars/dmzcluster.yml
+++ b/deployment/sandbox-v2/group_vars/dmzcluster.yml
@@ -5,7 +5,7 @@ cluster_name: 'dmzcluster'  # Same as in hosts.ini
 cluster_master: 'dmzmaster.sb' # Same as in hosts.ini
 
 # Kubernetes
-kube_version: v1.18.0
+kube_version: v1.19.0
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true

--- a/deployment/sandbox-v2/group_vars/mzcluster.yml
+++ b/deployment/sandbox-v2/group_vars/mzcluster.yml
@@ -5,7 +5,7 @@ cluster_name: 'mzcluster'  # Same as in hosts.ini
 cluster_master: 'mzmaster.sb' # Same as in hosts.ini
 
 # Kubernetes
-kube_version: v1.18.0
+kube_version: v1.19.0
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true


### PR DESCRIPTION
The kubernetes control plane and kubelet version are a mismatch currently.
The kubernetes control plane is hardcoded as 1.18.0, where the kubelet downloads the latest kubernetes version (1.19.0).

Until we are able to hardcode the kubelet version, we should update the control plane version to prevent broken deployments.