### PR TITLE
[MOSIP-10291] Backup resolv file

### DIFF
--- a/deployment/sandbox-v2/playbooks/coredns.yml
+++ b/deployment/sandbox-v2/playbooks/coredns.yml
@@ -10,6 +10,12 @@
 - hosts: all
   gather_facts: false
   tasks:
+   - name: Backup resolv file
+     copy:
+       src: '/etc/resolv.conf'
+       dest: '/etc/resolv.conf.bak'
+     become: yes
+
    - name: Replace resolv file
      template:
        src: '{{install_root}}/roles/coredns/templates/resolv.conf.j2'


### PR DESCRIPTION
While installing coredns we remove the original /etc/resolv.conf from all the hosts and replace with ours.  Ideally, we must save the original file as /etc/resolv.conf.bak.
So, there is a code change in playbooks/coredns.yml to be applied on all hosts to solve this issue.