### PR TITLE
[MOSIP-10856] View-only Kuberentes dashbaord

### DIFF
--- a/deployment/sandbox-v2/roles/k8scluster/dashboard/tasks/main.yml
+++ b/deployment/sandbox-v2/roles/k8scluster/dashboard/tasks/main.yml
@@ -1,28 +1,46 @@
 # Kubernetes dashboard tasks
 
-- name: Create dashboard yml from template 
+- name: Create dashboard yml from template
   template:
     src:  dashboard.yml.j2
     dest: '{{tmp_dir}}/{{cluster_name}}_dashboard.yml'
 
 - name: 'Create {{cluster_name}} dashboard'
   command: 'kubectl --kubeconfig={{kube_config}} apply -f {{tmp_dir}}/{{cluster_name}}_dashboard.yml'
-  register: create_result
-  until: create_result.rc == 0
+  register: create_result_admin
+  until: create_result_admin.rc == 0
   retries: 5
   delay: 2
   ignore_errors: true
 
-- name:  Get dashboard token  
-  shell: '{{install_root}}/utils/get_dashboard_token.py {{kube_config}}' 
-  register: token
+- name: Create view-only dashboard
+  command: 'kubectl --kubeconfig={{kube_config}} apply -f {{install_root}}/roles/k8scluster/dashboard/templates/view-dashboard.yaml'
+  register: create_result_view
+  until: create_result_view.rc == 0
+  retries: 5
+  delay: 2
+  ignore_errors: true
+
+- name:  Get dashboard token
+  shell: '{{install_root}}/utils/get_dashboard_token.py {{kube_config}} admin-user {{install_root}}/utils/mz_dashboard_admin.token' 
+  register: token_admin
+
+- name:  Get dashboard token
+  shell: '{{install_root}}/utils/get_dashboard_token.py {{kube_config}} view-user {{install_root}}/utils/mz_dashboard_view.token'
+  register: token_view
 
 - debug:
-    msg: '{{token.stdout}}'
+    msg: '{{token_admin.stdout}}'
 
-- name: 'Copy the token to {{dashboard_conf.token_file}}' 
+- debug:
+    msg: '{{token_view.stdout}}'
+
+- name: 'Copy the token to {{dashboard_conf.token_file}}'
   copy:
-    content: "{{token.stdout}}\n"
+    content: "{{token_admin.stdout}}\n"
     dest: '{{dashboard_conf.token_file}}'
 
-
+- name: 'Copy the token to {{dashboard_conf.token_file}}'
+  copy:
+    content: "{{token_view.stdout}}\n"
+    dest: '{{dashboard_conf.token_file}}'

--- a/deployment/sandbox-v2/roles/k8scluster/dashboard/templates/view-dashboard.yaml
+++ b/deployment/sandbox-v2/roles/k8scluster/dashboard/templates/view-dashboard.yaml
@@ -1,0 +1,153 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: view-dashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: view-user
+  namespace: kubernetes-dashboard
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: view-user
+  labels:
+    k8s-app: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dashboard-viewonly
+subjects:
+- kind: ServiceAccount
+  name: view-user
+  namespace: kubernetes-dashboard

--- a/deployment/sandbox-v2/utils/get_dashboard_token.py
+++ b/deployment/sandbox-v2/utils/get_dashboard_token.py
@@ -1,22 +1,48 @@
-#!/usr/bin/python
-# Given a kube config file, pull out the dashboard token.  The token is 
-# needed to login into the dashboard.
-# Usage: ./get_dashboard_token <kube config path> 
-# Output: Token string on stdout 
+#!/bin/python3
+# Usage: (Example)
+# $ ./get_dashboard_token.py admin-user /home/mosipuser/.kube/mzcluster.config mz_dashboard_admin.token
 
 import subprocess
 import sys
+import traceback
+import argparse
 
-if len(sys.argv) != 2:
-  print('Usage: get_dashboard_token <kube config path>')
-  exit(0)
+SERVICE_ACCOUNTS = ['admin-user', 'view-user']
 
-kubeconfig = sys.argv[1]
+def get_dashboard_token(service_account, kubeconfig):
+    out = subprocess.check_output("kubectl --kubeconfig %s -n kubernetes-dashboard describe secret $(kubectl --kubeconfig %s -n kubernetes-dashboard get secret | grep ^%s| awk '{print $1}')" % (kubeconfig, kubeconfig, service_account), shell=True)
+    out = out.decode() # bytes -> str
+    token = '' 
+    lines = out.split('\n')
+    for line in lines:
+        if line.startswith('token: '):
+            token = line.split()[1]
+    return token
 
-out = subprocess.check_output("kubectl --kubeconfig %s -n kubernetes-dashboard describe secret $(kubectl --kubeconfig %s -n kubernetes-dashboard get secret | grep ^admin-user | awk '{print $1}')" % (kubeconfig, kubeconfig), shell=True)
+def args_parse():
+    parser = argparse.ArgumentParser()
+    required = parser.add_argument_group('required arguments')
+    required.add_argument('kubeconfig', type=str, help='Path to kubectl config file')
+    required.add_argument('service_account', type=str, help='admin-user|view-user')
+    parser.add_argument('outfile', type=str, help='Token output file path')
+    args = parser.parse_args()
+    return args, parser
 
-lines = out.split('\n')
+def main():
+    args, parser =  args_parse()
+    if args.service_account not in SERVICE_ACCOUNTS:
+        parser.print_help()
+        sys.exit(1)
+    try:
+        token = get_dashboard_token(args.service_account, args.kubeconfig)
+        fp = open(args.outfile, 'wt')
+        fp.write(token)
+        fp.close()
+    except:
+        formatted_lines = traceback.format_exc()
+        print(formatted_lines)
+        sys.exit(2)
+    sys.exit(0)
 
-for line in lines:
-  if line.startswith('token: '):
-    print(line.split()[1])
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
Implemeting access control on standard k8s dashboard such that:
1. With Admin user (token) all operations are possible on the dashboard
2. With a View-Only user (token) the dashboard can be viewed,  logs can be viewed but cannot add/modify/delete any resource.