### PR TITLE
MOSIP-10835 : Reset playbook added for kafka and few config changes done.

### DIFF
--- a/deployment/sandbox-v2/group_vars/all.yml
+++ b/deployment/sandbox-v2/group_vars/all.yml
@@ -385,6 +385,7 @@ coredns:
 
 iam_adapter_url: http://artifactory-service/artifactory/libs-release-local/io/mosip/kernel/kernel-auth-adapter.jar
 #The below auth adaptor is build with vertx 3.9.1 to be compatible with regproc stages and services
-iam_adapter_ext_url: '{{clusters.mz.ingress.base_url}}/artifactory/libs-release-local/io/mosip/kernel/kernel-auth-adapter-1.2.0-SNAPSHOT-regproc-20201209055103.jar'
+iam_adapter_regproc_url: 'http://artifactory-service/artifactory/libs-snapshot-local/io/mosip/kernel/kernel-auth-adapter/1.2.0-SNAPSHOT/kernel-auth-adapter-1.2.0-SNAPSHOT-regproc-20201209055103.jar'
+iam_adapter_regproc_ext_url: '{{clusters.mz.ingress.base_url}}/artifactory/libs-snapshot-local/io/mosip/kernel/kernel-auth-adapter/1.2.0-SNAPSHOT/kernel-auth-adapter-1.2.0-SNAPSHOT-regproc-20201209055103.jar'
 runtimeDepUrlpath: http://artifactory-service/artifactory/libs-release-local/io/mosip/kernel/
 biosdk_service_url: http://13.233.66.241/biosdk-service

--- a/deployment/sandbox-v2/helm/charts/dmzregproc/values.template.j2
+++ b/deployment/sandbox-v2/helm/charts/dmzregproc/values.template.j2
@@ -16,7 +16,7 @@ ingress:
    namespace: default
 
 artifactoryUrl: {{ artifactory_url }} 
-iamAdapterUrl: {{ iam_adapter_ext_url }}
+iamAdapterUrl: {{ iam_adapter_regproc_ext_url }}
 
 isGlowroot: {{ is_glowroot }} 
 

--- a/deployment/sandbox-v2/helm/charts/regproc/values.template.j2
+++ b/deployment/sandbox-v2/helm/charts/regproc/values.template.j2
@@ -15,7 +15,7 @@ ingress:
    namespace: default
 
 artifactoryUrl: {{ artifactory_url }} 
-iamAdapterUrl: {{ iam_adapter_url }}
+iamAdapterUrl: {{ iam_adapter_regproc_url }}
 
 imagePullPolicy: Always 
 

--- a/deployment/sandbox-v2/playbooks/reset/reset-kafka.yml
+++ b/deployment/sandbox-v2/playbooks/reset/reset-kafka.yml
@@ -1,0 +1,28 @@
+# Delete monitoring  persistence
+- hosts: console
+  gather_facts: no
+  become: yes
+  vars_prompt:
+    - name: sure 
+      prompt: 'Do you want to ERASE all Kafka data? Are you sure? (yes/no)'
+      private: no
+  tasks:
+  - name: Delete kafka folders
+    block:
+      - name: Find all Kafka folders 
+        find:
+          paths: '{{nfs.folder}}' 
+          patterns: 'default-data-kafka*'
+          file_type: directory
+        register: dirs_to_be_deleted
+
+#      - debug:
+#          msg: '{{dirs_to_be_deleted.files}}'
+    
+      - name: Delete all kafka related folders
+        file:
+          path: "{{ item.path }}"
+          state: absent
+        with_items: "{{ dirs_to_be_deleted.files }}"
+    when: sure.lower().strip() == 'yes'
+

--- a/deployment/sandbox-v2/reset.yml
+++ b/deployment/sandbox-v2/reset.yml
@@ -15,3 +15,4 @@
 - {import_playbook: playbooks/reset/reset-repos.yml}
 - {import_playbook: playbooks/reset/reset-docker-registry.yml}
 - {import_playbook: playbooks/reset/reset-nginx.yml}
+- {import_playbook: playbooks/reset/reset-kafka.yml}


### PR DESCRIPTION
1. Reset playbook added to clear the folders creaded in nfs by kafka pvc
2. Separate 2 config added for regproc iam adaptor because of vertx version conflict issue.

@ckm007 'kernel-auth-adapter-1.2.0-SNAPSHOT-regproc-20201209055103.jar' file to be added to artifactory image to the location 'http://artifactory-service/artifactory/libs-snapshot-local/io/mosip/kernel/kernel-auth-adapter/1.2.0-SNAPSHOT/kernel-auth-adapter-1.2.0-SNAPSHOT-regproc-20201209055103.jar'
