### PR TITLE
Fix: helm repo stable URL update

### DIFF
--- a/deployment/sandbox-v2/Contributors.md
+++ b/deployment/sandbox-v2/Contributors.md
@@ -1,0 +1,1 @@
+Phyo Min Htun

--- a/deployment/sandbox-v2/roles/packages/helm-cli/tasks/main.yml
+++ b/deployment/sandbox-v2/roles/packages/helm-cli/tasks/main.yml
@@ -17,7 +17,7 @@
     mode: 0755
 
 - name: Add stable repo
-  shell: '{{helm_cli_path}}/helm repo add stable https://kubernetes-charts.storage.googleapis.com'
+  shell: '{{helm_cli_path}}/helm repo add stable https://charts.helm.sh/stable'
 
 - name: "Update Helm repo"
   shell: "{{helm_cli_path}}/helm repo update"  # Shell instead of command for getting all the paths


### PR DESCRIPTION
Helm stable repo modified in "/sandbox-v2/roles/packages/helm-cli/tasks" 
Current repo link is no longer support.
https://charts.helm.sh/stable/