### PR TITLE
tweak wireguard config and locked cryptography to 3.3.2

### DIFF
--- a/deployment/sandbox-v2/docs/wireguard.md
+++ b/deployment/sandbox-v2/docs/wireguard.md
@@ -33,12 +33,11 @@ A signed module is available as built-in to CentOS's kernel-plus. Run these sequ
 	The configuration file should be over-written with below set of lines:
 	```
 	[Interface]
-	Address = 10.100.100.1/24
+	Address = 10.100.100.1/32
 	SaveConfig = true
 	PrivateKey = <private-key-of-server>
 	ListenPort = 51820
 	PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-
 	PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
 
 	[Peer]
@@ -85,9 +84,9 @@ Client OS may be different from CentOS 7, so whichever OS is it, you may install
 		
 		[Peer]
 		PublicKey = <public-key-of-server>
-		Endpoint = <private-ip-of-server>:51820
-		AllowedIPs = 0.0.0.0/0
-		PersistentKeepalive = 21
+		Endpoint = <public-ip-of-server>:51820
+		AllowedIPs = 10.0.0.0/8
+		PersistentKeepalive = 15
 	```
 4. Start wireguard on client:
 	``` $ sudo wg-quick up wg0-client```

--- a/deployment/sandbox-v2/roles/packages/crypto/tasks/main.yml
+++ b/deployment/sandbox-v2/roles/packages/crypto/tasks/main.yml
@@ -1,7 +1,8 @@
 
+#install specific cryptography version since >3.4 releases have rust dependency that throws an error.
 - name: Install python3 cryptography
   pip:
-    name: cryptography
+    name: cryptography==3.3.2
     state: present
     executable: /bin/pip3
   become: yes

--- a/deployment/sandbox-v2/roles/ssl/letsencrypt/tasks/main.yml
+++ b/deployment/sandbox-v2/roles/ssl/letsencrypt/tasks/main.yml
@@ -14,17 +14,21 @@
 - name: Upgrade pip to latest
   command: '{{ansible_env.HOME}}/.venv-py3/bin/pip install --upgrade pip'
 
+#install specific cryptography version since >3.4 releases have rust dependency that throws an error.
 - name: Install certbot in python3 virtual environment 
   pip:
-    name: certbot
-    version: '{{certbot_version}}' 
+    name: 
+      - cryptography==3.3.2
+      - 'certbot=={{certbot_version}}'
     virtualenv_python: python3
     virtualenv: '{{ansible_env.HOME}}/.venv-py3'
     state: present
 
 - name: Install certbot-nginx
   pip:
-    name: certbot-nginx
+    name: 
+      - cryptography==3.3.2
+      - 'certbot-nginx=={{certbot_nginx_version}}'
     version: '{{certbot_nginx_version}}' 
     virtualenv: '{{ansible_env.HOME}}/.venv-py3'
     state: present


### PR DESCRIPTION
update wireguard config to successfully connect while retaining ssh access.