### PR TITLE
accesscodelifespan is 1 min now

### DIFF
--- a/deployment/sandbox-v2/roles/keycloak-init/files/realms/realm_mosip.json
+++ b/deployment/sandbox-v2/roles/keycloak-init/files/realms/realm_mosip.json
@@ -1,5 +1,5 @@
 {
-    "accessCodeLifespan": 7200, 
+    "accessCodeLifespan": 60,
     "accessCodeLifespanLogin": 1800, 
     "accessCodeLifespanUserAction": 300, 
     "accessTokenLifespan": 86400, 
@@ -75,7 +75,7 @@
     "sslRequired": "all",
     "ssoSessionIdleTimeout": 86400, 
     "ssoSessionIdleTimeoutRememberMe": 0, 
-    "ssoSessionMaxLifespan": 36000, 
+    "ssoSessionMaxLifespan": 86400,
     "ssoSessionMaxLifespanRememberMe": 0, 
     "supportedLocales": [], 
     "userManagedAccessAllowed": false, 


### PR DESCRIPTION
Also 1 minute is the standard recommended time period.

Also ssosessionmaxlifespan is now 1 day.