### PR TITLE
[MOSIP-43615] Update Helm installation commands for IAM, Kafka, Minio and Postgres with new image repositories and tags

### DIFF
--- a/deployment/v3/external/iam/install.sh
+++ b/deployment/v3/external/iam/install.sh
@@ -17,10 +17,19 @@ function installing_keycloak() {
   ## TODO: enable istio injection after testing well.
   kubectl label ns $NS istio-injection=disabled --overwrite
   helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo add mosip https://mosip.github.io/mosip-helm
   helm repo update
 
   echo Installing
-  helm -n $NS install $SERVICE_NAME mosip/keycloak --version "7.1.18" --set image.repository=mosipqa/mosip-artemis-keycloak --set image.tag=develop --set image.pullPolicy=Always -f values.yaml --wait
+  helm -n $NS install $SERVICE_NAME mosip/keycloak \
+  --version "7.1.18" \
+  --set image.repository=mosipid/mosip-artemis-keycloak \
+  --set image.tag=1.2.0.1 \
+  --set image.pullPolicy=Always \
+  --set postgresql.image.repository=mosipid/postgresql \
+  --set postgresql.image.tag=14.2.0-debian-10-r70 \
+  -f values.yaml \
+  --wait
 
   echo Install Istio gateway, virtual service
   helm -n $NS install istio-addons mosip/istio-addons --version $ISTIO_ADDONS_CHART_VERSION -f istio-addons-values.yaml

--- a/deployment/v3/external/kafka/install.sh
+++ b/deployment/v3/external/kafka/install.sh
@@ -21,10 +21,16 @@ function installing_kafka() {
   echo Updating helm repos
   helm repo add kafka-ui https://provectus.github.io/kafka-ui-charts
   helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo add mosip https://mosip.github.io/mosip-helm
   helm repo update
 
   echo Installing kafka
-  helm -n $NS install kafka bitnami/kafka -f values.yaml --wait --version $CHART_VERSION
+  helm -n $NS install kafka bitnami/kafka \
+  --set image.repository="mosipid/kafka" \
+  --set image.tag="3.2.1-debian-11-r9" \
+  --set zookeeper.image.repository="mosipid/zookeeper" \
+  --set zookeeper.image.tag="3.8.0-debian-11-r30" \
+  -f values.yaml --wait --timeout=10m --version $CHART_VERSION
 
   echo Installing kafka-ui
   helm -n $NS install kafka-ui kafka-ui/kafka-ui -f ui-values.yaml --wait --version $UI_CHART_VERSION

--- a/deployment/v3/external/object-store/minio/install.sh
+++ b/deployment/v3/external/object-store/minio/install.sh
@@ -15,7 +15,10 @@ kubectl label ns $NS istio-injection=enabled --overwrite
 
 function installing_minio() {
   echo Installing minio
-  helm -n minio install minio bitnami/minio -f values.yaml --version 15.0.6
+  helm -n minio install minio mosip/minio \
+  --set image.repository="mosipid/minio" \
+  --set image.tag="2022.2.7-debian-10-r0" \
+  -f values.yaml --version 10.1.6
 
   echo Installing gateways and virtualservice
   helm -n $NS install istio-addons mosip/istio-addons --version $ISTIO_ADDONS_CHART_VERSION -f istio-addons-values.yaml

--- a/deployment/v3/external/postgres/install.sh
+++ b/deployment/v3/external/postgres/install.sh
@@ -16,7 +16,12 @@ kubectl label ns $NS istio-injection=enabled --overwrite
 
 function installing_postgres() {
   echo Installing  Postgres
-  helm -n $NS install postgres bitnami/postgresql --version 13.1.5 -f values.yaml --wait
+  helm -n $NS install postgres bitnami/postgresql --version 13.1.5 \
+  -f values.yaml \
+  --set image.repository=mosipid/postgresql \
+  --set image.tag=14.2.0-debian-10-r70 \
+  --set image.pullPolicy=Always \
+  --wait
   echo Installed Postgres
   echo Installing gateways and virtual services
   helm -n $NS install istio-addons mosip/istio-addons --version $ISTIO_ADDONS_CHART_VERSION -f istio-addons-values.yaml --wait


### PR DESCRIPTION
…, and Postgres with new image repositories and tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm repository configurations and container image references across deployment infrastructure.
  * Upgraded Keycloak, Kafka/Zookeeper, MinIO, and PostgreSQL services to use new image versions and repositories.
  * Enhanced deployment configurations with explicit image settings and pull policies for improved consistency and reliability across containerized services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->