### PR TITLE
[MOSIP-44117]Changed ClamAV image repository to mosipid/clamav

### DIFF
--- a/deployment/v3/external/antivirus/clamav/values.yaml
+++ b/deployment/v3/external/antivirus/clamav/values.yaml
@@ -2,7 +2,7 @@
 ## Increase in production
 replicaCount: 1
 ## We are using official clamav docker instead of mailu/clamav that was present originally
-#image:
- # repository: clamav/clamav
- # tag: 1.2
+image:
+  repository: mosipid/clamav
+  tag: 1.2
  # pullPolicy: Always


### PR DESCRIPTION
Updated the ClamAV image repository to 'mosipid/clamav'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated antivirus service container image configuration with version 1.2 locked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->