### PR TITLE
[MOSIP-44117]Updated ClamAV image tag to 1.3.0_base

### DIFF
--- a/deployment/v3/external/antivirus/clamav/values.yaml
+++ b/deployment/v3/external/antivirus/clamav/values.yaml
@@ -4,5 +4,5 @@ replicaCount: 1
 ## We are using official clamav docker instead of mailu/clamav that was present originally
 image:
   repository: mosipid/clamav
-  tag: 1.2
+  tag: 1.3.0_base
  # pullPolicy: Always


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the antivirus service deployment to use a newer image version for enhanced stability and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->