### PR TITLE
(MOSIP-44258) Deployment issues with 1.2.1.0 mosip-infra fixes

### DIFF
--- a/deployment/v3/external/object-store/minio/install.sh
+++ b/deployment/v3/external/object-store/minio/install.sh
@@ -18,7 +18,13 @@ function installing_minio() {
   helm -n minio install minio mosip/minio \
   --set image.repository="mosipid/minio" \
   --set image.tag="2022.2.7-debian-10-r0" \
-  --set global.security.allowInsecureImages=true \
+ALLOW_INSECURE_IMAGES="${ALLOW_INSECURE_IMAGES:-false}"
+
+  helm -n minio install minio mosip/minio \
+  --set image.repository="mosipid/minio" \
+  --set image.tag="2022.2.7-debian-10-r0" \
+  --set global.security.allowInsecureImages="${ALLOW_INSECURE_IMAGES}" \
+  -f values.yaml --version 10.1.6
   -f values.yaml --version 10.1.6
 
   echo Installing gateways and virtualservice

--- a/deployment/v3/external/object-store/minio/install.sh
+++ b/deployment/v3/external/object-store/minio/install.sh
@@ -18,15 +18,9 @@ function installing_minio() {
   helm -n minio install minio mosip/minio \
   --set image.repository="mosipid/minio" \
   --set image.tag="2022.2.7-debian-10-r0" \
-ALLOW_INSECURE_IMAGES="${ALLOW_INSECURE_IMAGES:-false}"
-
-  helm -n minio install minio mosip/minio \
-  --set image.repository="mosipid/minio" \
-  --set image.tag="2022.2.7-debian-10-r0" \
   --set global.security.allowInsecureImages="${ALLOW_INSECURE_IMAGES}" \
   -f values.yaml --version 10.1.6
-  -f values.yaml --version 10.1.6
-
+  
   echo Installing gateways and virtualservice
   helm -n $NS install istio-addons mosip/istio-addons --version $ISTIO_ADDONS_CHART_VERSION -f istio-addons-values.yaml
 

--- a/deployment/v3/external/object-store/minio/install.sh
+++ b/deployment/v3/external/object-store/minio/install.sh
@@ -18,6 +18,7 @@ function installing_minio() {
   helm -n minio install minio mosip/minio \
   --set image.repository="mosipid/minio" \
   --set image.tag="2022.2.7-debian-10-r0" \
+  --set global.security.allowInsecureImages=true \
   -f values.yaml --version 10.1.6
 
   echo Installing gateways and virtualservice

--- a/deployment/v3/mosip/config-server/copy_cm.sh
+++ b/deployment/v3/mosip/config-server/copy_cm.sh
@@ -10,6 +10,7 @@ function copying_cm() {
   $COPY_UTIL configmap activemq-activemq-artemis-share activemq $DST_NS
   $COPY_UTIL configmap s3 s3 $DST_NS
   $COPY_UTIL configmap msg-gateway msg-gateways $DST_NS
+  $COPY_UTIL configmap postgres-setup-config postgres $DST_NS
   return 0
 }
 

--- a/deployment/v3/mosip/prereg/install.sh
+++ b/deployment/v3/mosip/prereg/install.sh
@@ -30,12 +30,14 @@ function installing_prereg() {
   # Prefer YAML host if defined, else fallback
   FINAL_PREREG_HOST=${PREREG_GATEWAY_HOST:-$PREREG_HOST}
   echo Install prereg-gateway
-  helm -n $NS install prereg-gateway mosip/istio-addons \
+  : "${PREREG_GATEWAY_CHART_VERSION:?PREREG_GATEWAY_CHART_VERSION must be set}"
+
+  helm -n "$NS" install prereg-gateway mosip/istio-addons \
     --set istio.name=prereg-gateway \
     --set istio.ingressController=ingressgateway \
-    --set istio.host=$FINAL_PREREG_HOST \
-    --set istio.serviceHost=$PREREG_GATEWAY_SERVICE_HOST \
-    --version $PREREG_GATEWAY_CHART_VERSION
+    --set "istio.host=$FINAL_PREREG_HOST" \
+    --set "istio.serviceHost=$PREREG_GATEWAY_SERVICE_HOST" \
+    --version "$PREREG_GATEWAY_CHART_VERSION"
 
   echo Installing prereg-application
   helm -n $NS install prereg-application mosip/prereg-application --version $CHART_VERSION

--- a/deployment/v3/mosip/prereg/install.sh
+++ b/deployment/v3/mosip/prereg/install.sh
@@ -10,8 +10,8 @@ NS=prereg
 CHART_VERSION=0.0.1-develop
 
 # Static values from YAML
-PREREG_GATEWAY_HOST="sandbox.xyz.mosip.net"
-PREREG_GATEWAY_SERVICE_HOST="service-hostname"
+PREREG_GATEWAY_HOST="${PREREG_GATEWAY_HOST:-}"
+PREREG_GATEWAY_SERVICE_HOST="${PREREG_GATEWAY_SERVICE_HOST:-service-hostname}"
 
 echo Create $NS namespace
 kubectl create ns $NS || true
@@ -28,7 +28,7 @@ function installing_prereg() {
   PREREG_HOST=`kubectl get cm global -o jsonpath={.data.mosip-prereg-host}`
   
   # Prefer YAML host if defined, else fallback
-  FINAL_PREREG_HOST=${PREREG_GATEWAY_HOST:-$PREREG_HOST}
+  FINAL_PREREG_HOST="${PREREG_GATEWAY_HOST:-$PREREG_HOST}"
   echo Install prereg-gateway
   : "${PREREG_GATEWAY_CHART_VERSION:?PREREG_GATEWAY_CHART_VERSION must be set}"
 

--- a/deployment/v3/mosip/prereg/install.sh
+++ b/deployment/v3/mosip/prereg/install.sh
@@ -9,25 +9,33 @@ fi
 NS=prereg
 CHART_VERSION=0.0.1-develop
 
-echo Create $NS namespace
-kubectl create ns $NS
+# Static values from YAML
+PREREG_GATEWAY_HOST="sandbox.xyz.mosip.net"
+PREREG_GATEWAY_SERVICE_HOST="service-hostname"
 
+echo Create $NS namespace
+kubectl create ns $NS || true
 function installing_prereg() {
   echo Istio label
-  ## TODO: Istio proxy disabled for now as prereui does not come up if
-  ## envoy filter container gets installed after prereg container.
   kubectl label ns $NS istio-injection=disabled --overwrite
   helm repo update
-
+  
   echo Copy configmaps
   sed -i 's/\r$//' copy_cm.sh
   ./copy_cm.sh
-
+  
   API_HOST=`kubectl get cm global -o jsonpath={.data.mosip-api-host}`
   PREREG_HOST=`kubectl get cm global -o jsonpath={.data.mosip-prereg-host}`
-
+  
+  # Prefer YAML host if defined, else fallback
+  FINAL_PREREG_HOST=${PREREG_GATEWAY_HOST:-$PREREG_HOST}
   echo Install prereg-gateway
-  helm -n $NS install prereg-gateway mosip/prereg-gateway --set istio.hosts[0]=$PREREG_HOST --version $CHART_VERSION
+  helm -n $NS install prereg-gateway mosip/istio-addons \
+    --set istio.name=prereg-gateway \
+    --set istio.ingressController=ingressgateway \
+    --set istio.host=$FINAL_PREREG_HOST \
+    --set istio.serviceHost=$PREREG_GATEWAY_SERVICE_HOST \
+    --version $PREREG_GATEWAY_CHART_VERSION
 
   echo Installing prereg-application
   helm -n $NS install prereg-application mosip/prereg-application --version $CHART_VERSION


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MinIO installer now supports enabling insecure container images during installation.
  * Config sync adds the PostgreSQL setup configuration to the config-server.

* **New Features**
  * Prereg deployment accepts explicit gateway/service host settings and installs the gateway via the Istio addons path with configurable host and chart version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-infra/pull/1827)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->