### PR TITLE
feat(deployment): update SSL renewal utility and configure automatic …

### DIFF
--- a/.github/workflows/mosip_repo_scanner.yml
+++ b/.github/workflows/mosip_repo_scanner.yml
@@ -64,5 +64,5 @@ jobs:
         run: 'curl  args: -u ''${{secrets.reporting_user}}:${{secrets.reporting_user_secret}}'' --request POST -F file=@./Reports_`date +%d%b%y`.zip -H ''Accept: application/json'' -H ''X-Atlassian-Token: no-check'' --url https://mosip.atlassian.net/wiki/rest/api/content/45285493/child/attachment'
 
       #Delete the reports from deployment server
-      - name: Create directory for reports
+      - name: Cleanup workspace
         run: rm -Rf ./*

--- a/.github/workflows/mosip_repo_scanner.yml
+++ b/.github/workflows/mosip_repo_scanner.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip3 install truffleHog3
+          pip3 install -y truffleHog3
 
       # Create List of all repos
       - name: Create repo list

--- a/.github/workflows/mosip_repo_scanner.yml
+++ b/.github/workflows/mosip_repo_scanner.yml
@@ -25,7 +25,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip3 install -y truffleHog3
+          pip3 install truffleHog3
 
       # Create List of all repos
       - name: Create repo list

--- a/.github/workflows/mosip_repo_scanner.yml
+++ b/.github/workflows/mosip_repo_scanner.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip3 install -y truffleHog3
+          pip3 install truffleHog3
 
       # Create List of all repos
       - name: Create repo list

--- a/deployment/v3/utils/ssl_renewel_util/README.md
+++ b/deployment/v3/utils/ssl_renewel_util/README.md
@@ -1,0 +1,41 @@
+# SSL Renewal Utility
+
+This utility installs a daily cron job to renew Let's Encrypt certificates and reload nginx automatically.
+
+## Files
+
+- `certs_renew_cron.sh`: installs or updates the daily cronjob.
+- `renew_ssl_certs.sh`: runs `certbot renew` and reloads nginx when renewal succeeds.
+
+## Usage
+
+1. Copy both scripts to the nginx VM under `/opt/ssl_renewal` or another stable location.
+2. Make both scripts executable:
+
+```bash
+sudo chmod +x certs_renew_cron.sh renew_ssl_certs.sh
+```
+
+3. Install the cron job:
+
+```bash
+sudo ./certs_renew_cron.sh
+```
+
+4. Verify the cron entry:
+
+```bash
+sudo crontab -l | grep renew_ssl_certs.sh
+```
+
+## Requirements
+
+- `certbot` installed on the nginx VM
+- `nginx` service present on the VM
+- SSL certificates managed under `/etc/letsencrypt`
+
+## Notes
+
+- The cron job runs daily at midnight.
+- Renewal output is logged to `/var/log/ssl_renewal.log`.
+- Cron installer logs to `/var/log/ssl_renewal.cron.log`.

--- a/deployment/v3/utils/ssl_renewel_util/certs_renew_cron.sh
+++ b/deployment/v3/utils/ssl_renewel_util/certs_renew_cron.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Install or update a cron job that runs the SSL renewal script daily.
+# Usage: sudo ./certs_renew_cron.sh
+
+set -euo pipefail
+
+if [ "$EUID" -ne 0 ]; then
+  echo "ERROR: This script must be run as root." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RENEW_SCRIPT="$SCRIPT_DIR/renew_ssl_certs.sh"
+LOG_FILE="/var/log/ssl_renewal.cron.log"
+CRON_SCHEDULE="0 0 * * *"
+CRON_COMMAND="$RENEW_SCRIPT >> $LOG_FILE 2>&1"
+CRON_LINE="$CRON_SCHEDULE $CRON_COMMAND"
+
+test -f "$RENEW_SCRIPT" || {
+  echo "ERROR: Renewal helper not found at $RENEW_SCRIPT" >&2
+  exit 1
+}
+
+tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile"' EXIT
+
+# Preserve existing crontab lines, but remove any old renewal entry for this helper.
+crontab -l 2>/dev/null | grep -v -F "$RENEW_SCRIPT" > "$tmpfile" || true
+
+echo "$CRON_LINE" >> "$tmpfile"
+crontab "$tmpfile"
+
+echo "Installed/updated SSL renewal cron job:"
+echo "  $CRON_LINE"
+echo "Renewal output will be logged to: $LOG_FILE"

--- a/deployment/v3/utils/ssl_renewel_util/renew_ssl_certs.sh
+++ b/deployment/v3/utils/ssl_renewel_util/renew_ssl_certs.sh
@@ -1,0 +1,44 @@
+# Run certbot renewal and reload nginx if certificates are renewed.
+# Usage: sudo ./renew_ssl_certs.sh
+
+set -euo pipefail
+
+LOG_FILE="/var/log/ssl_renewal.log"
+CERTBOT_BIN="$(command -v certbot || true)"
+
+if [ -z "$CERTBOT_BIN" ]; then
+  echo "ERROR: certbot is not installed. Install certbot before running this script." >&2
+  exit 1
+fi
+
+DEPLOY_HOOK=""
+if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files nginx.service >/dev/null 2>&1; then
+  DEPLOY_HOOK="systemctl reload nginx"
+elif command -v service >/dev/null 2>&1; then
+  DEPLOY_HOOK="service nginx reload"
+fi
+
+{
+  echo "[$(date +'%F %T')] Starting SSL certificate renewal."
+  if [ -n "$DEPLOY_HOOK" ]; then
+    if $CERTBOT_BIN renew --quiet --deploy-hook "$DEPLOY_HOOK"; then
+      echo "[$(date +'%F %T')] certbot renew completed successfully."
+    else
+      echo "[$(date +'%F %T')] certbot renew failed." >&2
+      exit 1
+    fi
+  else
+    echo "[$(date +'%F %T')] nginx reload command not found; running certbot renew without reload." >&2
+    if $CERTBOT_BIN renew --quiet; then
+      echo "[$(date +'%F %T')] certbot renew completed successfully." 
+      echo "[$(date +'%F %T')] Please reload nginx manually once certificates are updated." >&2
+    else
+      echo "[$(date +'%F %T')] certbot renew failed." >&2
+      exit 1
+    fi
+  fi
+} >> "$LOG_FILE" 2>&1
+
+# If certbot renewed any certificate, deploy-hook will reload nginx.
+
+echo "Renewal attempt finished. See $LOG_FILE for details." >&2


### PR DESCRIPTION
Summary
1) Added a new SSL renewal utility under [ssl_renewel_util]
2) Implemented [certs_renew_cron.sh] to install/update a daily cron job for SSL renewal
3) Implemented [renew_ssl_certs.sh] to run certbot renew and reload nginx automatically when certificates are refreshed
4) Added a README documenting installation, usage, and verification steps

What changed
1) [certs_renew_cron.sh]
     - validates root execution
     - preserves existing crontab entries
     - installs a daily midnight cron job to run the renewal helper
     - logs cron execution to /var/log/ssl_renewal.cron.log
2) [renew_ssl_certs.sh]
     - validates certbot presence
     - runs renewal in quiet mode
     - reloads nginx via systemctl or service when renewal succeeds
     - logs renewal output to /var/log/ssl_renewal.log
3) [README.md]
     - describes script usage, requirements, and verification commands
    
Testing
 - Verified both scripts syntactically with:
- bash -n certs_renew_cron.sh renew_ssl_certs.sh

 Note 
This PR provides the deployable utility for running on the nginx VM; actual VM installation requires copying the scripts to the target host and running sudo ./certs_renew_cron.sh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SSL renewal utility documentation with setup and verification steps.

* **New Features**
  * Introduced automated SSL certificate renewal with daily scheduled execution.
  * Added support for nginx reloading after certificate renewal.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-infra/pull/1828)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->