### PR TITLE
Closes #1857 activemq helm chart is failing with legacy script

### DIFF
--- a/deployment/v3/external/activemq/install.sh
+++ b/deployment/v3/external/activemq/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=activemq
-CHART_VERSION=0.0.3
+CHART_VERSION=0.0.4
 
 echo Create $NS namespace
 kubectl create ns $NS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ActiveMQ deployment configuration to use the latest Helm chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->