### PR TITLE
Update CHART_VERSION to 1.3.0 in upgrade script

### DIFF
--- a/deployment/v3/external/postgres/postgres-upgrade.sh
+++ b/deployment/v3/external/postgres/postgres-upgrade.sh
@@ -27,7 +27,7 @@ read_user_input(){
 }
 function initialize_db() {
   NS=postgres
-  CHART_VERSION=12.0.1
+  CHART_VERSION=1.3.0
   helm repo add mosip https://mosip.github.io/mosip-helm
   helm repo update
   while true; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL Helm chart deployment version from 12.0.1 to 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->