### PR TITLE
Point idrepo API TestRig at idrepo1230 (image 1.2.3.0)

### DIFF
--- a/deployment/v3/testrig/apitestrig-idrepo1230/README.md
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/README.md
@@ -1,0 +1,88 @@
+# Idrepo API TestRig → idrepo1230 (v1.2.3.0)
+
+Point the **idrepo-only** API TestRig at the parallel `idrepo1230` stack, using image tag **`mosipid/apitest-idrepo:1.2.3.0`**.
+
+## Why not change ENV_ENDPOINT?
+
+Apitestrig still needs Keycloak / authmanager / masterdata / etc. on the shared env.
+Keep:
+
+`ENV_ENDPOINT=https://api-internal.qa11new.mosip.net`
+
+Only **retarget Istio VirtualService destinations** for idrepo path prefixes so those paths hit `idrepo1230` services. No new Gateway is required.
+
+| Path prefix | Target service |
+|---|---|
+| `/idrepository/v1/identity` | `identity1230.idrepo1230` |
+| `/v1/credentialservice` | `credential1230.idrepo1230` |
+| `/v1/credentialrequest` | `credentialrequest1230.idrepo1230` |
+| `/idrepository/v1` (vid) | `vid1230.idrepo1230` |
+
+## Prerequisites
+
+1. `idrepo1230` pods are Running (identity / credential / credentialrequest / vid).
+2. Run apitestrig prereq once (config-server audience overrides), if not already done:
+   ```sh
+   cd ../apitestrig
+   ./prereq.sh
+   ```
+
+## Install steps
+
+```sh
+cd deployment/v3/testrig/apitestrig-idrepo1230
+chmod +x *.sh
+
+# 1) Point api-internal idrepo routes at idrepo1230 (backs up VS YAML under ./vs-backup/)
+./retarget-vs.sh
+
+# Optional: avoid duplicate routes if idrepo1230 also has VS with the same prefixes
+# kubectl -n idrepo1230 get virtualservice
+# kubectl -n idrepo1230 delete virtualservice --all
+
+# 2) Install idrepo-only apitestrig (tag 1.2.3.0)
+./install.sh
+```
+
+During `install.sh` prompts:
+- Cron hour (0–23)
+- Public domain / valid SSL? Use `n` for typical QA self-signed setups
+- Report retention days (default 3)
+- Slack webhook URL
+- eSignet deployed? (`yes`/`no`)
+
+## Run manually
+
+```sh
+kubectl -n apitestrig get cronjob | grep idrepo
+
+kubectl -n apitestrig create job --from=cronjob/cronjob-idrepo-apitestrig-idrepo \
+  idrepo-apitestrig-manual-$(date +%s)
+```
+
+CronJob name can vary slightly by chart version; confirm with `kubectl -n apitestrig get cronjob`.
+
+## Verify routes before running tests
+
+```sh
+API=$(kubectl -n default get cm global -o jsonpath='{.data.mosip-api-internal-host}')
+curl -sk "https://$API/idrepository/v1/identity/actuator/health"
+curl -sk "https://$API/v1/credentialservice/actuator/health"
+curl -sk "https://$API/v1/credentialrequest/actuator/health"
+curl -sk "https://$API/idrepository/v1/vid/actuator/health"
+```
+
+## Restore original idrepo routes
+
+```sh
+# If backups exist:
+kubectl -n idrepo apply -f ./vs-backup/
+```
+
+## Uninstall testrig only
+
+```sh
+./delete.sh
+```
+
+This does **not** restore VirtualServices; apply `./vs-backup/` separately if needed.

--- a/deployment/v3/testrig/apitestrig-idrepo1230/README.md
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/README.md
@@ -27,6 +27,14 @@ Only **retarget Istio VirtualService destinations** for idrepo path prefixes so 
    ./prereq.sh
    ```
 
+## Namespace
+
+Installs into **`apitestrig1230` by default**, not the existing `apitestrig` namespace.
+
+Do **not** reuse `apitestrig`: the install deletes/recreates shared configmaps (`s3`, `db`, `apitestrig`) and would break your current testrig. Helm release name is `idrepo-apitestrig`.
+
+Override if needed: `NS=apitestrig1230 ./install.sh`
+
 ## Install steps
 
 ```sh
@@ -40,7 +48,7 @@ chmod +x *.sh
 # kubectl -n idrepo1230 get virtualservice
 # kubectl -n idrepo1230 delete virtualservice --all
 
-# 2) Install idrepo-only apitestrig (tag 1.2.3.0)
+# 2) Install idrepo-only apitestrig (tag 1.2.3.0) into apitestrig1230
 ./install.sh
 ```
 
@@ -54,13 +62,13 @@ During `install.sh` prompts:
 ## Run manually
 
 ```sh
-kubectl -n apitestrig get cronjob | grep idrepo
+kubectl -n apitestrig1230 get cronjob | grep idrepo
 
-kubectl -n apitestrig create job --from=cronjob/cronjob-idrepo-apitestrig-idrepo \
+kubectl -n apitestrig1230 create job --from=cronjob/cronjob-idrepo-apitestrig-idrepo \
   idrepo-apitestrig-manual-$(date +%s)
 ```
 
-CronJob name can vary slightly by chart version; confirm with `kubectl -n apitestrig get cronjob`.
+CronJob name can vary slightly by chart version; confirm with `kubectl -n apitestrig1230 get cronjob`.
 
 ## Verify routes before running tests
 

--- a/deployment/v3/testrig/apitestrig-idrepo1230/copy_cm.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/copy_cm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copy configmaps from other namespaces
+# DST_NS: Destination namespace
+
+function copying_cm() {
+  COPY_UTIL=../../utils/copy_cm_func.sh
+  DST_NS=apitestrig
+  $COPY_UTIL configmap global default $DST_NS
+  $COPY_UTIL configmap keycloak-host keycloak $DST_NS
+  $COPY_UTIL configmap artifactory-share artifactory $DST_NS
+  $COPY_UTIL configmap config-server-share config-server $DST_NS
+  return 0
+}
+
+set -e
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+copying_cm

--- a/deployment/v3/testrig/apitestrig-idrepo1230/copy_cm.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/copy_cm.sh
@@ -4,7 +4,7 @@
 
 function copying_cm() {
   COPY_UTIL=../../utils/copy_cm_func.sh
-  DST_NS=apitestrig
+  DST_NS=${NS:-apitestrig1230}
   $COPY_UTIL configmap global default $DST_NS
   $COPY_UTIL configmap keycloak-host keycloak $DST_NS
   $COPY_UTIL configmap artifactory-share artifactory $DST_NS

--- a/deployment/v3/testrig/apitestrig-idrepo1230/copy_secrets.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/copy_secrets.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copy secrets from other namespaces
+# DST_NS: Destination namespace
+
+function copying_secrets() {
+  COPY_UTIL=../../utils/copy_cm_func.sh
+  DST_NS=apitestrig
+  $COPY_UTIL secret keycloak-client-secrets keycloak $DST_NS
+  $COPY_UTIL secret s3 s3 $DST_NS
+  $COPY_UTIL secret postgres-postgresql postgres $DST_NS
+  return 0
+}
+
+set -e
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+copying_secrets

--- a/deployment/v3/testrig/apitestrig-idrepo1230/copy_secrets.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/copy_secrets.sh
@@ -4,7 +4,7 @@
 
 function copying_secrets() {
   COPY_UTIL=../../utils/copy_cm_func.sh
-  DST_NS=apitestrig
+  DST_NS=${NS:-apitestrig1230}
   $COPY_UTIL secret keycloak-client-secrets keycloak $DST_NS
   $COPY_UTIL secret s3 s3 $DST_NS
   $COPY_UTIL secret postgres-postgresql postgres $DST_NS

--- a/deployment/v3/testrig/apitestrig-idrepo1230/delete.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/delete.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Uninstalls idrepo-apitestrig release
+## Usage: ./delete.sh [kubeconfig]
+
+if [ $# -ge 1 ] ; then
+  export KUBECONFIG=$1
+fi
+
+function deleting_apitestrig() {
+  NS=apitestrig
+  RELEASE_NAME=idrepo-apitestrig
+  while true; do
+      read -p "Are you sure you want to delete $RELEASE_NAME helm chart?(Y/n) " yn
+      if [ "$yn" = "Y" ]
+        then
+          helm -n $NS delete $RELEASE_NAME
+          break
+        else
+          break
+      fi
+    done
+  return 0
+}
+
+set -e
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+deleting_apitestrig

--- a/deployment/v3/testrig/apitestrig-idrepo1230/delete.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/delete.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 function deleting_apitestrig() {
-  NS=apitestrig
+  NS=${NS:-apitestrig1230}
   RELEASE_NAME=idrepo-apitestrig
   while true; do
       read -p "Are you sure you want to delete $RELEASE_NAME helm chart?(Y/n) " yn

--- a/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
@@ -128,8 +128,9 @@ function installing_apitestrig() {
   --set apitestrig.configmaps.apitestrig.NS="$NS" \
   $ENABLE_INSECURE
 
-  echo Installed $RELEASE_NAME.
+  echo Installed $RELEASE_NAME into namespace $NS.
   echo
+  echo "Run manually:"
   echo "  kubectl -n $NS create job --from=cronjob/cronjob-${RELEASE_NAME}-idrepo idrepo-apitestrig-manual-\$(date +%s)"
   return 0
 }

--- a/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
@@ -7,12 +7,15 @@ if [ $# -ge 1 ] ; then
   export KUBECONFIG=$1
 fi
 
-NS=apitestrig
+# Use a dedicated namespace so the existing apitestrig install is not disturbed.
+# Shared CM names (s3, db, apitestrig) would otherwise be deleted/overwritten.
+NS=${NS:-apitestrig1230}
 RELEASE_NAME=idrepo-apitestrig
 CHART_VERSION=1.5.0
 
 echo Create $NS namespace
 kubectl create ns $NS 2>/dev/null || true
+export NS
 
 function installing_apitestrig() {
   echo Istio label
@@ -127,7 +130,6 @@ function installing_apitestrig() {
 
   echo Installed $RELEASE_NAME.
   echo
-  echo "Run manually:"
   echo "  kubectl -n $NS create job --from=cronjob/cronjob-${RELEASE_NAME}-idrepo idrepo-apitestrig-manual-\$(date +%s)"
   return 0
 }

--- a/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/install.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Installs idrepo-only apitestrig (image tag 1.2.3.0) against api-internal,
+# which should already be retargeted to idrepo1230 via ./retarget-vs.sh
+## Usage: ./install.sh [kubeconfig]
+
+if [ $# -ge 1 ] ; then
+  export KUBECONFIG=$1
+fi
+
+NS=apitestrig
+RELEASE_NAME=idrepo-apitestrig
+CHART_VERSION=1.5.0
+
+echo Create $NS namespace
+kubectl create ns $NS 2>/dev/null || true
+
+function installing_apitestrig() {
+  echo Istio label
+  kubectl label ns $NS istio-injection=disabled --overwrite
+
+  helm repo update
+
+  echo Copy configmaps
+  ./copy_cm.sh
+
+  echo Copy secrets
+  ./copy_secrets.sh
+
+  echo "Delete s3, db, & apitestrig configmap if exists"
+  kubectl -n $NS delete --ignore-not-found=true configmap s3
+  kubectl -n $NS delete --ignore-not-found=true configmap db
+  kubectl -n $NS delete --ignore-not-found=true configmap apitestrig
+
+  API_INTERNAL_HOST=$( kubectl -n default get cm global -o json  | jq -r '.data."mosip-api-internal-host"' )
+  DB_HOST=$API_INTERNAL_HOST
+  ENV_USER=$( kubectl -n default get cm global -o json | jq -r '.data."mosip-api-internal-host"' | awk -F '.' '/api-internal/{print $1"."$2}')
+
+  echo "Target ENV_ENDPOINT will be: https://$API_INTERNAL_HOST"
+  echo "Ensure idrepo routes on this host already point to idrepo1230 (run ./retarget-vs.sh first)."
+
+  read -p "Please enter the time(hr) to run the cronjob every day (time: 0-23) : " time
+  if [ -z "$time" ]; then
+     echo "ERROR: Time cannot be empty; EXITING;";
+     exit 1;
+  fi
+  if ! [ $time -eq $time ] 2>/dev/null; then
+     echo "ERROR: Time $time is not a number; EXITING;";
+     exit 1;
+  fi
+  if [ $time -gt 23 ] || [ $time -lt 0 ] ; then
+     echo "ERROR: Time should be in range ( 0-23 ); EXITING;";
+     exit 1;
+  fi
+
+  echo "Do you have public domain & valid SSL? (Y/n) "
+  echo "Y: if you have public domain & valid ssl certificate"
+  echo "n: If you don't have a public domain and a valid SSL certificate. Note: It is recommended to use this option only in development environments."
+  read -p "" flag
+
+  if [ -z "$flag" ]; then
+    echo "'flag' was provided; EXITING;"
+    exit 1;
+  fi
+  ENABLE_INSECURE=''
+  if [ "$flag" = "n" ]; then
+    ENABLE_INSECURE='--set enable_insecure=true';
+  fi
+
+  read -p "Please provide the retention days to remove old reports ( Default: 3 )" reportExpirationInDays
+
+  if [[ -z $reportExpirationInDays ]]; then
+    reportExpirationInDays=3
+  fi
+  if ! [[ $reportExpirationInDays =~ ^[0-9]+$ ]]; then
+    echo "The variable \"reportExpirationInDays\" should contain only number; EXITING";
+    exit 1;
+  fi
+
+  read -p "Please provide slack webhook URL to notify server end issues on your slack channel : " slackWebhookUrl
+
+  if [ -z "$slackWebhookUrl" ]; then
+    echo "slack webhook URL not provided; EXITING;"
+    exit 1;
+  fi
+
+  valid_inputs=("yes" "no")
+  eSignetDeployed=""
+
+  while [[ ! " ${valid_inputs[*]} " =~ " ${eSignetDeployed} " ]]; do
+      read -p "Is the eSignet service deployed? (yes/no): " eSignetDeployed
+      eSignetDeployed=${eSignetDeployed,,}
+  done
+
+  if [[ $eSignetDeployed == "yes" ]]; then
+      echo "eSignet service is deployed. Proceeding with installation..."
+  else
+      echo "eSignet service is not deployed. hence will be skipping esignet related test-cases..."
+  fi
+
+  # Uninstall previous release of the same name if present
+  if helm -n $NS status $RELEASE_NAME >/dev/null 2>&1; then
+    echo "Existing release $RELEASE_NAME found; upgrading..."
+    HELM_CMD=upgrade
+  else
+    HELM_CMD=install
+  fi
+
+  echo "Installing/upgrading idrepo apitestrig (image mosipid/apitest-idrepo:1.2.3.0)"
+  helm -n $NS $HELM_CMD $RELEASE_NAME mosip/apitestrig \
+  --set crontime="0 $time * * *" \
+  -f values.yaml \
+  --version $CHART_VERSION \
+  --set apitestrig.configmaps.s3.s3-host='http://minio.minio:9000' \
+  --set apitestrig.configmaps.s3.s3-user-key='admin' \
+  --set apitestrig.configmaps.s3.s3-region='' \
+  --set apitestrig.configmaps.db.db-server="$DB_HOST" \
+  --set apitestrig.configmaps.db.db-su-user="postgres" \
+  --set apitestrig.configmaps.db.db-port="5432" \
+  --set apitestrig.configmaps.apitestrig.ENV_USER="$ENV_USER" \
+  --set apitestrig.configmaps.apitestrig.ENV_ENDPOINT="https://$API_INTERNAL_HOST" \
+  --set apitestrig.configmaps.apitestrig.ENV_TESTLEVEL="smokeAndRegression" \
+  --set apitestrig.configmaps.apitestrig.reportExpirationInDays="$reportExpirationInDays" \
+  --set apitestrig.configmaps.apitestrig.slack-webhook-url="$slackWebhookUrl" \
+  --set apitestrig.configmaps.apitestrig.eSignetDeployed="$eSignetDeployed" \
+  --set apitestrig.configmaps.apitestrig.NS="$NS" \
+  $ENABLE_INSECURE
+
+  echo Installed $RELEASE_NAME.
+  echo
+  echo "Run manually:"
+  echo "  kubectl -n $NS create job --from=cronjob/cronjob-${RELEASE_NAME}-idrepo idrepo-apitestrig-manual-\$(date +%s)"
+  return 0
+}
+
+set -e
+set -o errexit
+set -o nounset
+set -o errtrace
+set -o pipefail
+installing_apitestrig

--- a/deployment/v3/testrig/apitestrig-idrepo1230/retarget-vs.sh
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/retarget-vs.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Point existing api-internal idrepo VirtualService routes at the idrepo1230 services.
+# Apitestrig keeps ENV_ENDPOINT=https://api-internal.<env> (authmanager etc. stay on the live cluster).
+# Only idrepo path prefixes are retargeted to the parallel stack.
+## Usage: ./retarget-vs.sh [kubeconfig]
+
+if [ $# -ge 1 ] ; then
+  export KUBECONFIG=$1
+fi
+
+OLD_NS=${OLD_NS:-idrepo}
+NEW_NS=${NEW_NS:-idrepo1230}
+GATEWAY=${GATEWAY:-istio-system/internal}
+
+# Helm release names in idrepo1230 (from parallel install)
+IDENTITY_SVC=${IDENTITY_SVC:-identity1230}
+CREDENTIAL_SVC=${CREDENTIAL_SVC:-credential1230}
+CREDENTIALREQUEST_SVC=${CREDENTIALREQUEST_SVC:-credentialrequest1230}
+VID_SVC=${VID_SVC:-vid1230}
+
+set -euo pipefail
+
+echo "Retargeting idrepo VirtualServices"
+echo "  old namespace (VS to patch): $OLD_NS"
+echo "  new services namespace:      $NEW_NS"
+echo "  gateway:                    $GATEWAY"
+echo
+
+# Map: vs_name|destination_service|uri_prefix
+ROUTES=(
+  "identity|${IDENTITY_SVC}|/idrepository/v1/identity"
+  "credential|${CREDENTIAL_SVC}|/v1/credentialservice"
+  "credentialrequest|${CREDENTIALREQUEST_SVC}|/v1/credentialrequest"
+  "vid|${VID_SVC}|/idrepository/v1"
+)
+
+confirm_services() {
+  local svc=$1
+  if ! kubectl -n "$NEW_NS" get svc "$svc" >/dev/null 2>&1; then
+    echo "ERROR: Service $svc not found in namespace $NEW_NS"
+    echo "Available services:"
+    kubectl -n "$NEW_NS" get svc
+    exit 1
+  fi
+  echo "OK: $svc.$NEW_NS"
+}
+
+echo "Checking target services exist..."
+for route in "${ROUTES[@]}"; do
+  IFS='|' read -r _ svc _ <<<"$route"
+  confirm_services "$svc"
+done
+echo
+
+patch_or_create_vs() {
+  local vs_name=$1
+  local dest_svc=$2
+  local prefix=$3
+  local dest_host="${dest_svc}.${NEW_NS}.svc.cluster.local"
+
+  if kubectl -n "$OLD_NS" get virtualservice "$vs_name" >/dev/null 2>&1; then
+    echo "Patching VirtualService $OLD_NS/$vs_name -> $dest_host (prefix $prefix)"
+    # Backup first
+    mkdir -p ./vs-backup
+    kubectl -n "$OLD_NS" get virtualservice "$vs_name" -o yaml > "./vs-backup/${vs_name}.yaml"
+    kubectl -n "$OLD_NS" patch virtualservice "$vs_name" --type=json -p="[
+      {\"op\":\"replace\",\"path\":\"/spec/http/0/route/0/destination/host\",\"value\":\"${dest_host}\"}
+    ]"
+  else
+    echo "VirtualService $OLD_NS/$vs_name not found; creating one that routes to $dest_host"
+    cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ${vs_name}
+  namespace: ${OLD_NS}
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - ${GATEWAY}
+  http:
+  - match:
+    - uri:
+        prefix: ${prefix}
+    route:
+    - destination:
+        host: ${dest_host}
+        port:
+          number: 80
+    headers:
+      request:
+        set:
+          x-forwarded-proto: https
+EOF
+  fi
+}
+
+for route in "${ROUTES[@]}"; do
+  IFS='|' read -r vs_name dest_svc prefix <<<"$route"
+  patch_or_create_vs "$vs_name" "$dest_svc" "$prefix"
+done
+
+echo
+echo "Done. Current VirtualServices in $OLD_NS:"
+kubectl -n "$OLD_NS" get virtualservice -o wide
+
+echo
+echo "Also check for conflicting VS in $NEW_NS (same path prefixes on same gateway):"
+kubectl -n "$NEW_NS" get virtualservice 2>/dev/null || echo "(none)"
+
+echo
+echo "NOTE: If $NEW_NS also has VirtualServices with the same URI prefixes,"
+echo "disable them to avoid ambiguous routing, e.g.:"
+echo "  kubectl -n $NEW_NS delete virtualservice --all"
+echo "Backups of patched VS (if any) are under ./vs-backup/"
+echo
+echo "Quick health checks (from a pod / wireguard):"
+echo "  curl -sk https://\$(kubectl -n default get cm global -o jsonpath='{.data.mosip-api-internal-host}')/idrepository/v1/identity/actuator/health"
+echo "  curl -sk https://\$(kubectl -n default get cm global -o jsonpath='{.data.mosip-api-internal-host}')/v1/credentialservice/actuator/health"

--- a/deployment/v3/testrig/apitestrig-idrepo1230/values.yaml
+++ b/deployment/v3/testrig/apitestrig-idrepo1230/values.yaml
@@ -1,0 +1,18 @@
+# Idrepo-only API TestRig for parallel idrepo1230 stack (v1.2.3.0)
+modules:
+  prereg:
+    enabled: false
+  masterdata:
+    enabled: false
+  idrepo:
+    enabled: true
+    image:
+      repository: mosipid/apitest-idrepo
+      tag: 1.2.3.0
+      pullPolicy: Always
+  partner:
+    enabled: false
+  resident:
+    enabled: false
+  auth:
+    enabled: false

--- a/deployment/v3/testrig/apitestrig/values.yaml
+++ b/deployment/v3/testrig/apitestrig/values.yaml
@@ -15,7 +15,7 @@ modules:
     enabled: true
     image:
       repository: mosipid/apitest-idrepo
-      tag: 1.3.0
+      tag: 1.2.3.0
       pullPolicy: Always
   partner:
     enabled: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an idrepo-only API TestRig package for the parallel `idrepo1230` stack and bumps the shared idrepo apitest image tag to `1.2.3.0`.

## Approach
- Keep `ENV_ENDPOINT=https://api-internal.<env>` so Keycloak/authmanager/other modules stay on the live env.
- Retarget existing idrepo VirtualService destinations to `identity1230` / `credential1230` / `credentialrequest1230` / `vid1230` in namespace `idrepo1230` (no new Gateway).
- Install Helm release `idrepo-apitestrig` with `mosipid/apitest-idrepo:1.2.3.0` into a **dedicated namespace `apitestrig1230`** so the existing `apitestrig` install is not overwritten (shared CMs: `s3`, `db`, `apitestrig`).

## How to use on qa11new
```sh
cd deployment/v3/testrig/apitestrig-idrepo1230
./retarget-vs.sh
./install.sh   # installs into apitestrig1230
```

See `deployment/v3/testrig/apitestrig-idrepo1230/README.md` for restore steps and manual job run commands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31c1434b-df96-49cd-8bb2-e29242c783b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31c1434b-df96-49cd-8bb2-e29242c783b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

