### PR TITLE
Closes #1950 Add kafka-restart-util under deployment/v3/utils

### DIFF
--- a/deployment/v3/utils/kafka-restart-util/README.md
+++ b/deployment/v3/utils/kafka-restart-util/README.md
@@ -10,12 +10,15 @@ zero first so its PVC is not held open while the brokers bounce.
 ## Restart sequence
 
 1. Record the current replica count of every `websub` deployment, then scale
-   them all to 0 and wait for the pods to terminate.
+   them all to 0 and wait for the pods to terminate. If the replica counts
+   cannot be read, the script aborts here without touching anything (see
+   [Behaviour on failure](#behaviour-on-failure)).
 2. Restart the `kafka` statefulsets (kafka + zookeeper) and the `kafka-ui`
    deployment together, then wait for all of them to become ready.
 3. Scale `websub-consolidator` back up, then `websub`, then any other
-   deployment in the namespace — each restored to the replica count recorded
-   in step 1, not blindly to 1.
+   deployment recorded in step 1 — each restored to the exact replica count it
+   had, not blindly to 1. A deployment that was already at 0 replicas is left
+   down rather than being brought up.
 4. Restart `kernel/syncdata`, then `kernel/masterdata`.
 5. Restart every deployment in the `ida` namespace and wait for all of them.
 6. Trigger `idrepo`, `pms`, `resident`, `print`, `digitalcard` and the
@@ -48,16 +51,37 @@ chmod +x kafka-restart.sh
 
 ## Behaviour on failure
 
-The script deliberately does **not** use `set -e`. A rollout that times out or
-a step that fails logs a warning and the run continues to the next module, so a
-single slow service cannot leave the cluster half-restarted. Every warning is
-collected and reprinted as a summary at the end, and the script always exits 0.
+Once the restart is under way the script deliberately does **not** use
+`set -e`. A rollout that times out or a step that fails logs a warning and the
+run continues to the next module, so a single slow service cannot leave the
+cluster half-restarted. Every warning is collected and reprinted as a summary
+at the end, and the script exits 0.
 
 If the summary is non-empty, the named services may simply still be starting:
 
 ```sh
 kubectl get pods -A
 ```
+
+### The one case that aborts
+
+Reading the `websub` replica counts in step 1 is a hard pre-condition. If that
+`kubectl get` fails, or returns no deployments at all, the script prints a
+`FATAL` line and **exits 1 without modifying anything**.
+
+This is deliberate. Scaling `websub` to zero without a record of what to
+restore would strand deployments at zero replicas with nothing to recover them
+from, so the safe response is to stop before the first destructive step rather
+than proceed on a guess. Nothing has been scaled or restarted at that point,
+so the script is safe to simply re-run once the cause is fixed — usually a
+wrong `kubectl` context, a missing `websub` namespace, or RBAC.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Run completed. Check the summary for warnings. |
+| `1`  | Pre-flight failure reading websub replica counts. Nothing was modified. |
 
 ## Requirements
 

--- a/deployment/v3/utils/kafka-restart-util/README.md
+++ b/deployment/v3/utils/kafka-restart-util/README.md
@@ -1,0 +1,71 @@
+# Kafka restart utility
+
+Shell script to restart Kafka and every MOSIP module that depends on it, in the
+correct order, on Kubernetes.
+
+Restarting Kafka on its own is not enough — Zookeeper, `kafka-ui` and all the
+downstream consumers have to be cycled with it, and `websub` must be scaled to
+zero first so its PVC is not held open while the brokers bounce.
+
+## Restart sequence
+
+1. Record the current replica count of every `websub` deployment, then scale
+   them all to 0 and wait for the pods to terminate.
+2. Restart the `kafka` statefulsets (kafka + zookeeper) and the `kafka-ui`
+   deployment together, then wait for all of them to become ready.
+3. Scale `websub-consolidator` back up, then `websub`, then any other
+   deployment in the namespace — each restored to the replica count recorded
+   in step 1, not blindly to 1.
+4. Restart `kernel/syncdata`, then `kernel/masterdata`.
+5. Restart every deployment in the `ida` namespace and wait for all of them.
+6. Trigger `idrepo`, `pms`, `resident`, `print`, `digitalcard` and the
+   `regproc-notifier` / `regproc-workflow` / `regproc-reprocess` deployments
+   simultaneously, then wait for every rollout.
+
+## Usage
+
+```sh
+./kafka-restart.sh                 # 300s wait per rollout (default)
+TIMEOUT=600s ./kafka-restart.sh    # custom wait per rollout
+```
+
+The script acts on the **current `kubectl` context**. Confirm it before running:
+
+```sh
+kubectl config current-context
+```
+
+### If the file is not executable
+
+The script is committed with mode `755`, so a `git clone` or an extracted
+ZIP/tarball of the repository already gives you an executable file. A file
+fetched over plain HTTP — `curl`/`wget` against `raw.githubusercontent.com`,
+or copy-pasted into an editor — cannot carry a permission bit, and will need:
+
+```sh
+chmod +x kafka-restart.sh
+```
+
+## Behaviour on failure
+
+The script deliberately does **not** use `set -e`. A rollout that times out or
+a step that fails logs a warning and the run continues to the next module, so a
+single slow service cannot leave the cluster half-restarted. Every warning is
+collected and reprinted as a summary at the end, and the script always exits 0.
+
+If the summary is non-empty, the named services may simply still be starting:
+
+```sh
+kubectl get pods -A
+```
+
+## Requirements
+
+* `kubectl`, configured and pointing at the target cluster
+* Permission to `scale`, `rollout restart` and `rollout status` in the
+  `websub`, `kafka`, `kernel`, `ida`, `idrepo`, `pms`, `resident`, `print`,
+  `digitalcard` and `regproc` namespaces
+* **bash 4.4 or newer.** The script uses an associative array (`declare -A`)
+  to record replica counts, and relies on `${#array[@]}` being safe on an empty
+  array under `set -u` — both need 4.4+. Ubuntu 20.04 and later ship 5.x;
+  older jump hosts and stock macOS bash 3.2 will not work.

--- a/deployment/v3/utils/kafka-restart-util/kafka-restart.sh
+++ b/deployment/v3/utils/kafka-restart-util/kafka-restart.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# kafka-restart.sh
+# Sequentially restarts Kafka and its dependent modules.
+# Designed to NEVER abort on timeouts or individual failures — it logs a
+# warning and moves on to the next step.
+#
+# Usage:
+#   ./kafka-restart.sh              # default 300s wait per rollout
+#   TIMEOUT=600s ./kafka-restart.sh # custom wait time
+#
+
+set -u   # intentionally NOT using -e, so a failed step never kills the script
+
+TIMEOUT="${TIMEOUT:-300s}"
+
+WARNINGS=()
+
+# Original replica count of every websub deployment, captured before the
+# scale-down so the scale-up restores what was actually there (an HA install
+# may run more than one replica).
+declare -A WEBSUB_REPLICAS=()
+
+log()  { echo -e "\n==> [$(date '+%H:%M:%S')] $*"; }
+warn() {
+  echo -e "!!  [$(date '+%H:%M:%S')] WARNING: $* — continuing anyway"
+  WARNINGS+=("$*")
+}
+
+# Wait for one rollout; warn (don't fail) on timeout
+wait_rollout() {
+  local ns="$1" kind="$2" name="$3"
+  log "Waiting for ${kind}/${name} in ns=${ns} (timeout ${TIMEOUT})"
+  kubectl rollout status "${kind}/${name}" -n "${ns}" --timeout="${TIMEOUT}" \
+    || warn "TIMEOUT: ${kind}/${name} in ns=${ns} did not become ready within ${TIMEOUT}"
+}
+
+# Restart + wait for every object of a kind in a namespace
+restart_all_and_wait() {
+  local ns="$1" kind="$2"
+  log "Restarting all ${kind}s in ns=${ns}"
+  kubectl rollout restart -n "${ns}" "${kind}" || warn "restart of ${kind}s in ${ns} failed"
+  local name
+  for name in $(kubectl get "${kind}" -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    wait_rollout "${ns}" "${kind}" "${name}"
+  done
+}
+
+# Restart + wait for a single named object
+restart_one_and_wait() {
+  local ns="$1" kind="$2" name="$3"
+  log "Restarting ${kind}/${name} in ns=${ns}"
+  kubectl rollout restart -n "${ns}" "${kind}" "${name}" || warn "restart of ${kind}/${name} failed"
+  wait_rollout "${ns}" "${kind}" "${name}"
+}
+
+# Scale a deployment back to the replica count it had before the scale-down.
+# Falls back to 1 if nothing was captured, or if it was already at 0.
+scale_up_and_wait() {
+  local ns="$1" name="$2"
+  local reps="${WEBSUB_REPLICAS[${name}]:-1}"
+  if ! [[ "${reps}" =~ ^[0-9]+$ ]] || [ "${reps}" -eq 0 ]; then
+    warn "no usable pre-restart replica count for ${name} in ns=${ns} (got '${reps}') — defaulting to 1"
+    reps=1
+  fi
+  log "Scaling ${name} back to ${reps} replica(s) in ns=${ns}"
+  kubectl scale deployment "${name}" --replicas="${reps}" -n "${ns}" \
+    || warn "scale-up of ${name} to ${reps} failed"
+  wait_rollout "${ns}" deployment "${name}"
+}
+
+##############################################################################
+# 1. Scale down websub (protects its PVC during the Kafka restart)
+##############################################################################
+log "Recording current websub replica counts"
+while read -r _name _reps; do
+  [ -n "${_name}" ] || continue
+  WEBSUB_REPLICAS["${_name}"]="${_reps}"
+  echo "    ${_name} = ${_reps}"
+done < <(kubectl get deployment -n websub \
+           -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.replicas}{"\n"}{end}' 2>/dev/null)
+
+if [ ${#WEBSUB_REPLICAS[@]} -eq 0 ]; then
+  warn "could not read any websub deployment replica counts — scale-up will default to 1 replica each"
+fi
+
+log "Scaling down all websub deployments to 0"
+kubectl scale deployment --all --replicas=0 -n websub || warn "websub scale-down failed"
+
+log "Waiting for websub pods to terminate"
+kubectl wait --for=delete pod --all -n websub --timeout="${TIMEOUT}" \
+  || warn "some websub pods still terminating after ${TIMEOUT}"
+
+##############################################################################
+# 2. Restart Kafka + Zookeeper statefulsets and kafka-ui simultaneously
+##############################################################################
+log "Restarting kafka statefulsets (kafka + zookeeper) and kafka-ui together"
+kubectl rollout restart -n kafka statefulset || warn "restart of kafka statefulsets failed"
+kubectl rollout restart -n kafka deployment kafka-ui || warn "restart of kafka-ui failed"
+
+# Now wait for all of them to come back
+for name in $(kubectl get statefulset -n kafka -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+  wait_rollout kafka statefulset "${name}"
+done
+wait_rollout kafka deployment kafka-ui
+
+##############################################################################
+# 3. Bring websub back up (consolidator first, then websub, then any others)
+##############################################################################
+scale_up_and_wait websub websub-consolidator
+scale_up_and_wait websub websub
+
+for name in "${!WEBSUB_REPLICAS[@]}"; do
+  case "${name}" in
+    websub|websub-consolidator) continue ;;
+  esac
+  scale_up_and_wait websub "${name}"
+done
+
+##############################################################################
+# 4. Kernel services
+##############################################################################
+restart_one_and_wait kernel deployment syncdata
+restart_one_and_wait kernel deployment masterdata
+
+##############################################################################
+# 5. IDA namespace (sequential — completes before the parallel batch below)
+##############################################################################
+restart_all_and_wait ida deployment   # no name means ALL deployments in ns
+
+##############################################################################
+# 6. Everything after IDA — restarted SIMULTANEOUSLY
+#    (idrepo, pms, resident, print, digitalcard,
+#     regproc-notifier, regproc-workflow, regproc-reprocess)
+##############################################################################
+log "Triggering simultaneous restart of idrepo, pms, resident, print, digitalcard, regproc services"
+kubectl rollout restart -n idrepo deployment || warn "restart of idrepo deployments failed"
+kubectl rollout restart -n pms deployment || warn "restart of pms deployments failed"
+kubectl rollout restart -n resident deployment || warn "restart of resident deployments failed"
+kubectl rollout restart -n print deployment || warn "restart of print deployments failed"
+kubectl rollout restart -n digitalcard deployment || warn "restart of digitalcard deployments failed"
+kubectl rollout restart -n regproc deployment regproc-notifier || warn "restart of regproc-notifier failed"
+kubectl rollout restart -n regproc deployment regproc-workflow || warn "restart of regproc-workflow failed"
+kubectl rollout restart -n regproc deployment regproc-reprocess || warn "restart of regproc-reprocess failed"
+
+log "All restarts triggered. Now waiting for every new pod to come up..."
+
+# Wait for all deployments in the namespace-wide restarts
+for ns in idrepo pms resident print digitalcard; do
+  for name in $(kubectl get deployment -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    wait_rollout "${ns}" deployment "${name}"
+  done
+done
+# Wait for the individually named services
+wait_rollout regproc deployment regproc-notifier
+wait_rollout regproc deployment regproc-workflow
+wait_rollout regproc deployment regproc-reprocess
+
+##############################################################################
+# Summary
+##############################################################################
+if [ ${#WARNINGS[@]} -eq 0 ]; then
+  log "✅ ALL NEW PODS ARE UP — every service restarted and became ready within ${TIMEOUT}."
+else
+  log "⚠️  Restart cycle finished, but ${#WARNINGS[@]} warning(s) occurred:"
+  for w in "${WARNINGS[@]}"; do
+    echo "   - ${w}"
+  done
+  echo "   (These services may still be starting — check with: kubectl get pods -A)"
+fi
+exit 0

--- a/deployment/v3/utils/kafka-restart-util/kafka-restart.sh
+++ b/deployment/v3/utils/kafka-restart-util/kafka-restart.sh
@@ -21,10 +21,22 @@ WARNINGS=()
 # may run more than one replica).
 declare -A WEBSUB_REPLICAS=()
 
+# Print a timestamped progress line.
 log()  { echo -e "\n==> [$(date '+%H:%M:%S')] $*"; }
+
+# Record a non-fatal problem and carry on. Every warning is reprinted in the
+# summary at the end of the run.
 warn() {
   echo -e "!!  [$(date '+%H:%M:%S')] WARNING: $* — continuing anyway"
   WARNINGS+=("$*")
+}
+
+# Abort the run. Only used for pre-flight failures, before any cluster state
+# has been touched, so it is always safe to simply re-run the script.
+fatal() {
+  echo -e "\n!!  [$(date '+%H:%M:%S')] FATAL: $*"
+  echo "    Nothing has been modified — no service was scaled down or restarted."
+  exit 1
 }
 
 # Wait for one rollout; warn (don't fail) on timeout
@@ -54,14 +66,19 @@ restart_one_and_wait() {
   wait_rollout "${ns}" "${kind}" "${name}"
 }
 
-# Scale a deployment back to the replica count it had before the scale-down.
-# Falls back to 1 if nothing was captured, or if it was already at 0.
+# Scale a deployment back to the exact replica count recorded before the
+# scale-down. A deployment that was already at 0 is left down: restoring it to
+# 1 would change cluster state the operator did not ask us to change.
 scale_up_and_wait() {
   local ns="$1" name="$2"
-  local reps="${WEBSUB_REPLICAS[${name}]:-1}"
-  if ! [[ "${reps}" =~ ^[0-9]+$ ]] || [ "${reps}" -eq 0 ]; then
-    warn "no usable pre-restart replica count for ${name} in ns=${ns} (got '${reps}') — defaulting to 1"
-    reps=1
+  local reps="${WEBSUB_REPLICAS[${name}]:-}"
+  if ! [[ "${reps}" =~ ^[0-9]+$ ]]; then
+    warn "no recorded replica count for ${name} in ns=${ns} — leaving it scaled down"
+    return
+  fi
+  if [ "${reps}" -eq 0 ]; then
+    log "${name} in ns=${ns} was at 0 replicas before the restart — leaving it down"
+    return
   fi
   log "Scaling ${name} back to ${reps} replica(s) in ns=${ns}"
   kubectl scale deployment "${name}" --replicas="${reps}" -n "${ns}" \
@@ -72,16 +89,24 @@ scale_up_and_wait() {
 ##############################################################################
 # 1. Scale down websub (protects its PVC during the Kafka restart)
 ##############################################################################
+# Record what is running before anything is scaled down. This is a hard
+# pre-condition: scaling websub to zero without a record of what to restore
+# would strand deployments at zero replicas with no way to recover them, so a
+# failure here aborts the run rather than proceeding on a guess.
 log "Recording current websub replica counts"
+if ! websub_rows="$(kubectl get deployment -n websub \
+      -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.replicas}{"\n"}{end}')"; then
+  fatal "could not read websub deployment replica counts in ns=websub. Check cluster connectivity, the current kubectl context and RBAC, then re-run."
+fi
+
 while read -r _name _reps; do
   [ -n "${_name}" ] || continue
   WEBSUB_REPLICAS["${_name}"]="${_reps}"
   echo "    ${_name} = ${_reps}"
-done < <(kubectl get deployment -n websub \
-           -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.replicas}{"\n"}{end}' 2>/dev/null)
+done <<< "${websub_rows}"
 
 if [ ${#WEBSUB_REPLICAS[@]} -eq 0 ]; then
-  warn "could not read any websub deployment replica counts — scale-up will default to 1 replica each"
+  fatal "no deployments found in ns=websub. Confirm you are pointed at the right cluster: kubectl config current-context"
 fi
 
 log "Scaling down all websub deployments to 0"
@@ -107,8 +132,10 @@ wait_rollout kafka deployment kafka-ui
 ##############################################################################
 # 3. Bring websub back up (consolidator first, then websub, then any others)
 ##############################################################################
-scale_up_and_wait websub websub-consolidator
-scale_up_and_wait websub websub
+# Consolidator first, then websub, then anything else that was recorded.
+for name in websub-consolidator websub; do
+  [ -n "${WEBSUB_REPLICAS[${name}]:-}" ] && scale_up_and_wait websub "${name}"
+done
 
 for name in "${!WEBSUB_REPLICAS[@]}"; do
   case "${name}" in


### PR DESCRIPTION
Closes #1950

### What this adds

`deployment/v3/utils/kafka-restart-util/` — a self-contained script that
restarts Kafka and every MOSIP module that depends on it, in the correct order.

    deployment/v3/utils/kafka-restart-util/
    ├── kafka-restart.sh   (mode 100755)
    └── README.md

### Sequence

1. Record the replica count of every `websub` deployment, scale them all to 0
   and wait for the pods to terminate — this keeps the websub PVC from being
   held open while the brokers bounce.
2. Restart the `kafka` statefulsets (kafka + zookeeper) and the `kafka-ui`
   deployment together, then wait for all of them.
3. Scale `websub-consolidator` back up, then `websub`, then any other
   deployment in the namespace — each restored to its recorded replica count,
   so an HA install is not silently downscaled to a single replica.
4. Restart `kernel/syncdata` and `kernel/masterdata`.
5. Restart every deployment in `ida` and wait.
6. Trigger `idrepo`, `pms`, `resident`, `print`, `digitalcard` and the three
   `regproc` services in parallel, then wait for all rollouts.

### Notes for review

- **File mode.** `kafka-restart.sh` is committed as `100755`, so it is
  executable straight from a clone or an extracted ZIP/tarball with no `chmod`
  step. This is the point of #1950 and is worth confirming on merge:
  `git ls-tree HEAD deployment/v3/utils/kafka-restart-util/`. A file pulled
  over plain HTTP from `raw.githubusercontent.com` cannot carry a permission
  bit — the README documents `chmod +x` for that path.
- **No `set -e`, by design.** A rollout that times out logs a warning and the
  run continues to the next module, so one slow service cannot leave the
  cluster half-restarted. All warnings are reprinted as a summary at the end
  and the script always exits 0.
- **`TIMEOUT`** (default `300s`) sets the per-rollout wait.
- **Namespaces are hard-coded** to the standard MOSIP set. Happy to move them
  to a `modules.txt` in the style of `utils/refresh/` if reviewers prefer.
- **Requires bash 4.4+** for the associative array used to record replica
  counts; noted in the README.
- The script acts on the current `kubectl` context; the README says to confirm
  it before running.
